### PR TITLE
Update extract_antibody_fv.py

### DIFF
--- a/tools/extract_antibody_fv.py
+++ b/tools/extract_antibody_fv.py
@@ -35,9 +35,10 @@ def truncate_chain(pdb_string, chain, limit, chain_id):
         is_atom = line.startswith("ATOM")
         if not is_atom:
             continue
-
-        residx = int(line[22:26])
-        is_target_chain = line[21] == chain
+        # Sliding index for serial_number>=100000
+        slideIdx = 0 if len(line.split()[1])<6 else len(line.split()[1])-5
+        residx = int(line[22+slideIdx:26+slideIdx])
+        is_target_chain = line[21+slideIdx] == chain
         is_fv = residx <= limit
         if (is_atom and is_target_chain and is_fv):
 
@@ -47,7 +48,7 @@ def truncate_chain(pdb_string, chain, limit, chain_id):
                 # we use only first pairs
                 break
 
-            truncated_string += line[:21] + chain_id + line[22:]
+            truncated_string += line[:21+slideIdx] + chain_id + line[22+slideIdx:]
             truncated_string += "\n"
 
             prev = cur


### PR DESCRIPTION
I would like to propose a way to solve the bug caused by string index through index sliding of the line of pdb_string.

1. Why
The truncate_chain method assumes that serial_number, the second section of the line, consists of 5 digits, and handles pdb_string based on the index of the string.
However, if serial_number in the line is composed of more than 6 digits (100000), an error occurs and the case is as follows.

- Example line where the bug occur
'ATOM  100000  HA  ASP V  50     -84.500  -6.184-184.148  1.00 55.62           H  '

- Error message 
```
ValueError                                Traceback (most recent call last)
Cell In[30], line 7
      5 if not h_chain == 'NA':
      6     ab_chain += h_chain
----> 7     h_chain_string = truncate_chain(pdb_string, h_chain, 112, 'H')

Cell In[3], line 28, in truncate_chain(pdb_string, chain, limit, chain_id)
     25 if not is_atom:
     26     continue
---> 28 residx = int(line[22:26])
     29 is_target_chain = line[21] == chain
     30 is_fv = residx <= limit

ValueError: invalid literal for int() with base 10: 'V  5'
```
The truncate_chain method was designed to capture '  50', but 'V 5' was chosen, since serial_number is 6 digits.


2. What
Through the slideIdx variable, index sliding of lines is performed without significant changes in the code.

3. How
slideIdx is allocated as many digits if serial_number is greater than 5 digits.
(slideIdx is 0 if serial_number is less than or equal to 5 digits.)
In an operation based on the string index, slideIdx is added to the currently set line index.

4. Results
5,361 Fv regions are extracted as pdb files.

5. Additionally, to parse the 5,361 Fv regions extracted above into a json file...
In order to execute solvent/tools/preprocess_multimer_datasets.py, 
_parse_coordinates method in Biopython should be also revised with same way by sliding index.
( The method's link is https://github.com/biopython/biopython/blob/d416809344f1e345fbabbdaca4dd6dcf441e53bd/Bio/PDB/PDBParser.py#L168-L320 )